### PR TITLE
create generic webhook for webhook-based collectors

### DIFF
--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -109,9 +109,7 @@ func (r *CollectorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			log.Info("worker not found for collector", "collector", req.NamespacedName.String())
 		}
 
-		if _, ok := r.WebhookHandlers[webhookHandlerPath(c, req)]; ok {
-			delete(r.WebhookHandlers, webhookHandlerPath(c, req))
-		}
+		delete(r.WebhookHandlers, webhookHandlerPath(c, req))
 
 		err := c.Destroy(collectorWorker.context)
 		if err != nil {

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -59,6 +59,7 @@ var (
 // +kubebuilder:rbac:groups=rode.liatr.io,resources=collectors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
+// nolint: gocyclo
 func (r *CollectorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log.WithValues("collector", req.NamespacedName)

--- a/helm-chart/rode/templates/service.yaml
+++ b/helm-chart/rode/templates/service.yaml
@@ -17,6 +17,10 @@ spec:
       {{- end }}
       protocol: TCP
       name: rode
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: collector-webhook
   selector:
     app: {{ template "rode.name" . }}
     release: {{ .Release.Name }}

--- a/main.go
+++ b/main.go
@@ -151,9 +151,10 @@ func main() {
 	mgr.GetWebhookServer().Register("/validate-v1-pod", &webhook.Admission{Handler: enforcer})
 
 	go func() {
-		err := webhookServer.ListenAndServe()
-		setupLog.Error(err, "error starting webhook server")
-		os.Exit(1)
+		if err := webhookServer.ListenAndServe(); err != nil {
+			setupLog.Error(err, "error starting webhook server")
+			os.Exit(1)
+		}
 	}()
 
 	signalHandler := ctrl.SetupSignalHandler()

--- a/pkg/collector/ecr_events.go
+++ b/pkg/collector/ecr_events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -45,7 +46,7 @@ func (i *ecrCollector) Type() string {
 	return "ecr_event"
 }
 
-func (i *ecrCollector) Reconcile(ctx context.Context) error {
+func (i *ecrCollector) Reconcile(ctx context.Context, name types.NamespacedName) error {
 	err := i.reconcileSQS(ctx)
 	if err != nil {
 		return err

--- a/pkg/collector/ecr_events.go
+++ b/pkg/collector/ecr_events.go
@@ -41,6 +41,10 @@ func NewEcrEventCollector(logger logr.Logger, awsConfig *aws.Config, queueName s
 	}
 }
 
+func (i *ecrCollector) Type() string {
+	return "ecr_event"
+}
+
 func (i *ecrCollector) Reconcile(ctx context.Context) error {
 	err := i.reconcileSQS(ctx)
 	if err != nil {

--- a/pkg/collector/test_collector.go
+++ b/pkg/collector/test_collector.go
@@ -21,7 +21,7 @@ func NewTestCollector(logger logr.Logger, testMessage string) Collector {
 	}
 }
 
-func (i *testCollector) Type() string {
+func (t *testCollector) Type() string {
 	return "test"
 }
 

--- a/pkg/collector/test_collector.go
+++ b/pkg/collector/test_collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	"time"
 
@@ -25,7 +26,7 @@ func (t *testCollector) Type() string {
 	return "test"
 }
 
-func (t *testCollector) Reconcile(ctx context.Context) error {
+func (t *testCollector) Reconcile(ctx context.Context, name types.NamespacedName) error {
 	t.logger.Info("reconciling test collector")
 
 	return nil
@@ -49,7 +50,7 @@ func (t *testCollector) Start(ctx context.Context, stopChan chan interface{}, oc
 	return nil
 }
 
-func (t *testCollector) HandleWebhook(writer http.ResponseWriter, request *http.Request) {
+func (t *testCollector) HandleWebhook(writer http.ResponseWriter, request *http.Request, occurrenceCreator occurrence.Creator) {
 	t.logger.Info("got request for test collector")
 
 	writer.WriteHeader(http.StatusOK)

--- a/pkg/collector/test_collector.go
+++ b/pkg/collector/test_collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -18,6 +19,10 @@ func NewTestCollector(logger logr.Logger, testMessage string) Collector {
 		logger:      logger,
 		testMessage: testMessage,
 	}
+}
+
+func (i *testCollector) Type() string {
+	return "test"
 }
 
 func (t *testCollector) Reconcile(ctx context.Context) error {
@@ -42,6 +47,12 @@ func (t *testCollector) Start(ctx context.Context, stopChan chan interface{}, oc
 	}()
 
 	return nil
+}
+
+func (t *testCollector) HandleWebhook(writer http.ResponseWriter, request *http.Request) {
+	t.logger.Info("got request for test collector")
+
+	writer.WriteHeader(http.StatusOK)
 }
 
 func (t *testCollector) Destroy(ctx context.Context) error {

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"github.com/liatrio/rode/pkg/occurrence"
+	"net/http"
 )
 
 // Collector converts events to occurrences
@@ -18,4 +19,13 @@ type Collector interface {
 	// Start handles the logic required for the collector to receive events and create occurrences using the provided
 	// `occurrenceCreator`
 	Start(ctx context.Context, stopChan chan interface{}, occurrenceCreator occurrence.Creator) error
+
+	// Type returns the type of this collector
+	Type() string
+}
+
+// WebhookCollector receives events as HTTP payloads and converts them to occurrences
+type WebhookCollector interface {
+	// HandleWebhook handles a given HTTP request for this collector and converts it into occurrences
+	HandleWebhook(writer http.ResponseWriter, request *http.Request)
 }

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"github.com/liatrio/rode/pkg/occurrence"
+	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 )
 
@@ -10,15 +11,12 @@ import (
 type Collector interface {
 	// Reconcile handles creating and updating any external resources that are required for your collector to function
 	// properly. Reconcile should be idempotent.
+	// The `name` parameter can be used to help provide names for the external resources managed by Reconcile.
 	// Example: the ECR collector will use the Reconcile function to create and update SQS queues and CloudWatch events
-	Reconcile(ctx context.Context) error
+	Reconcile(ctx context.Context, name types.NamespacedName) error
 
 	// Destroy handles the deletion of resources that were created in the Reconcile function
 	Destroy(ctx context.Context) error
-
-	// Start handles the logic required for the collector to receive events and create occurrences using the provided
-	// `occurrenceCreator`
-	Start(ctx context.Context, stopChan chan interface{}, occurrenceCreator occurrence.Creator) error
 
 	// Type returns the type of this collector
 	Type() string
@@ -26,6 +24,13 @@ type Collector interface {
 
 // WebhookCollector receives events as HTTP payloads and converts them to occurrences
 type WebhookCollector interface {
-	// HandleWebhook handles a given HTTP request for this collector and converts it into occurrences
-	HandleWebhook(writer http.ResponseWriter, request *http.Request)
+	// HandleWebhook handles a given HTTP request for this collector and converts it into occurrences using the provided
+	// `occurrenceCreator`
+	HandleWebhook(writer http.ResponseWriter, request *http.Request, occurrenceCreator occurrence.Creator)
+}
+
+type StartableCollector interface {
+	// Start handles the logic required for the collector to receive events and create occurrences using the provided
+	// `occurrenceCreator`
+	Start(ctx context.Context, stopChan chan interface{}, occurrenceCreator occurrence.Creator) error
 }


### PR DESCRIPTION
initial stab at adding a generic webhook for collectors that are webhook-based.  to opt-in, the collector just needs to implement the `WebhookCollector` interface.

if a collector implements this interface, I am not really sure if/how the existing `Start` method will be used.  looking for feedback