### PR TITLE
Updated apiVersion and spec selector for localstack

### DIFF
--- a/helm-chart/rode/charts/localstack/templates/deployment.yaml
+++ b/helm-chart/rode/charts/localstack/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
   template:
     metadata:
       labels:

--- a/helm-chart/rode/charts/localstack/templates/deployment.yaml
+++ b/helm-chart/rode/charts/localstack/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "name" . }}
+      release: {{ .Release.name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR updates the `apiVersion` and `spec.selector` of the `deployment` resource for localstack to satisfy Kubernetes `1.16`