### PR TITLE
Eng 1868

### DIFF
--- a/pkg/collector/ecr_events.go
+++ b/pkg/collector/ecr_events.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	discovery "github.com/grafeas/grafeas/proto/v1beta1/discovery_go_proto"
 	grafeas "github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
@@ -28,6 +29,10 @@ type ecrCollector struct {
 	queueURL     string
 	queueARN     string
 	ruleComplete bool
+}
+
+type ecrClient interface {
+	DescribeImageScanFindings(input *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error)
 }
 
 // NewEcrEventCollector will create an collector of ECR events from Cloud watch
@@ -161,24 +166,24 @@ func (i *ecrCollector) reconcileCWEvent(ctx context.Context) error {
 		Attributes: map[string]*string{
 			"Policy": aws.String(fmt.Sprintf(`
 {
-	"Version": "2012-10-17",
-	"Id": "queue-policy",
-	"Statement": [
-		{
-			"Sid": "cloudwatch-event-rule",
-			"Effect": "Allow",
-			"Principal": {
-				"Service": "events.amazonaws.com"
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "%s",
-			"Condition": {
-				"ArnEquals": {
-					"aws:SourceArn": "%s"
-				}
-			}
-		}
-	]
+  "Version": "2012-10-17",
+  "Id": "queue-policy",
+  "Statement": [
+    {
+      "Sid": "cloudwatch-event-rule",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "%s",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "%s"
+        }
+      }
+    }
+  ]
 }`, i.queueARN, aws.StringValue(ruleResp.RuleArn)))}})
 
 	err = req.Send()
@@ -297,7 +302,10 @@ func (i *ecrCollector) watchQueue(ctx context.Context, svc *sqs.SQS, occurrenceC
 				return err
 			}
 
-			occurrences = i.newImageScanOccurrences(event, details)
+			occurrences, err = i.newImageScanOccurrences(event, details)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = occurrenceCreator.CreateOccurrences(ctx, occurrences...)
@@ -338,36 +346,55 @@ func EcrOccurrenceNote(queueName string) string {
 	return fmt.Sprintf("projects/%s/notes/%s", "rode", queueName)
 }
 
-func getVulnerabilityDetails(detail *ECRImageScanDetail) []*grafeas.Occurrence_Vulnerability {
-	// TODO: load from ecr scan results
+func getVulnerabilityDetails(c ecrClient, detail *ECRImageScanDetail) ([]*grafeas.Occurrence_Vulnerability, error) {
 	vulnerabilityDetails := make([]*grafeas.Occurrence_Vulnerability, 0)
 
-	for k, v := range detail.FindingsSeverityCounts {
-		severity := getVulnerabilitySeverity(k)
+	imageScanInput := &ecr.DescribeImageScanFindingsInput{
+		ImageId:        &ecr.ImageIdentifier{ImageDigest: &detail.ImageDigest},
+		RepositoryName: aws.String(detail.RepositoryName),
+	}
 
-		for i := int64(0); i < v; i++ {
-			v := &grafeas.Occurrence_Vulnerability{
-				Vulnerability: &vulnerability.Details{
-					Severity: severity,
-					PackageIssue: []*vulnerability.PackageIssue{
-						{
-							AffectedLocation: &vulnerability.VulnerabilityLocation{
-								CpeUri:  "TODO",
-								Package: "TODO",
-								Version: &packag.Version{
-									Kind: packag.Version_NORMAL,
-									Name: "TODO",
-								},
+	scanFindings, err := c.DescribeImageScanFindings(imageScanInput)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range scanFindings.ImageScanFindings.Findings {
+
+		var packageUri, packageName, packageVersion string
+		packageSeverity := getVulnerabilitySeverity(*p.Severity)
+
+		for _, k := range p.Attributes {
+			if *k.Key == "package_name" {
+				packageName = *k.Value
+			} else if *k.Key == "package_version" {
+				packageVersion = *k.Value
+			}
+		}
+
+		packageUri = *p.Uri
+
+		v := &grafeas.Occurrence_Vulnerability{
+			Vulnerability: &vulnerability.Details{
+				Severity: packageSeverity,
+				PackageIssue: []*vulnerability.PackageIssue{
+					{
+						AffectedLocation: &vulnerability.VulnerabilityLocation{
+							CpeUri:  packageUri,
+							Package: packageName,
+							Version: &packag.Version{
+								Kind: packag.Version_NORMAL,
+								Name: packageVersion,
 							},
 						},
 					},
 				},
-			}
-			vulnerabilityDetails = append(vulnerabilityDetails, v)
+			},
 		}
+		vulnerabilityDetails = append(vulnerabilityDetails, v)
 	}
 
-	return vulnerabilityDetails
+	return vulnerabilityDetails, nil
 }
 
 func getVulnerabilitySeverity(v string) vulnerability.Severity {
@@ -387,7 +414,7 @@ func getVulnerabilitySeverity(v string) vulnerability.Severity {
 	}
 }
 
-func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *ECRImageScanDetail) []*grafeas.Occurrence {
+func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *ECRImageScanDetail) (occurrences []*grafeas.Occurrence, err error) {
 	tags := detail.ImageTags
 	if len(tags) == 0 {
 		tags = []string{"latest"}
@@ -396,9 +423,15 @@ func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *E
 	status := discovery.Discovered_ANALYSIS_STATUS_UNSPECIFIED
 	vulnerabilityDetails := make([]*grafeas.Occurrence_Vulnerability, 0)
 
+	ses := session.Must(session.NewSession(i.awsConfig))
+	ecrClient := ecr.New(ses)
+
 	if detail.ScanStatus == "COMPLETE" {
 		status = discovery.Discovered_FINISHED_SUCCESS
-		vulnerabilityDetails = getVulnerabilityDetails(detail)
+		vulnerabilityDetails, err = getVulnerabilityDetails(ecrClient, detail)
+		if err != nil {
+			return nil, err
+		}
 	} else if detail.ScanStatus == "FAILED" {
 		status = discovery.Discovered_FINISHED_FAILED
 	}
@@ -411,7 +444,7 @@ func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *E
 		},
 	}
 
-	occurrences := make([]*grafeas.Occurrence, 0)
+	occurrences = make([]*grafeas.Occurrence, 0)
 	for _, tag := range tags {
 		o := newImageScanOccurrence(event, detail, tag, i.queueName)
 		o.Details = discoveryDetails
@@ -424,7 +457,7 @@ func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *E
 		}
 	}
 
-	return occurrences
+	return occurrences, nil
 }
 func (i *ecrCollector) newImageActionOccurrences(event *CloudWatchEvent, detail *ECRImageActionDetail) []*grafeas.Occurrence {
 	return nil

--- a/pkg/collector/ecr_events.go
+++ b/pkg/collector/ecr_events.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
 
@@ -414,7 +415,7 @@ func getVulnerabilitySeverity(v string) vulnerability.Severity {
 	}
 }
 
-func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *ECRImageScanDetail) (occurrences []*grafeas.Occurrence, err error) {
+func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *ECRImageScanDetail) ([]*grafeas.Occurrence, error) {
 	tags := detail.ImageTags
 	if len(tags) == 0 {
 		tags = []string{"latest"}
@@ -427,6 +428,7 @@ func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *E
 	ecrClient := ecr.New(ses)
 
 	if detail.ScanStatus == "COMPLETE" {
+		var err error
 		status = discovery.Discovered_FINISHED_SUCCESS
 		vulnerabilityDetails, err = getVulnerabilityDetails(ecrClient, detail)
 		if err != nil {
@@ -444,7 +446,7 @@ func (i *ecrCollector) newImageScanOccurrences(event *CloudWatchEvent, detail *E
 		},
 	}
 
-	occurrences = make([]*grafeas.Occurrence, 0)
+	occurrences := make([]*grafeas.Occurrence, 0)
 	for _, tag := range tags {
 		o := newImageScanOccurrence(event, detail, tag, i.queueName)
 		o.Details = discoveryDetails

--- a/pkg/collector/ecr_events.go
+++ b/pkg/collector/ecr_events.go
@@ -361,7 +361,7 @@ func getVulnerabilityDetails(c ecrClient, detail *ECRImageScanDetail) ([]*grafea
 
 	for _, p := range scanFindings.ImageScanFindings.Findings {
 
-		var packageUri, packageName, packageVersion string
+		var packageURI, packageName, packageVersion string
 		packageSeverity := getVulnerabilitySeverity(*p.Severity)
 
 		for _, k := range p.Attributes {
@@ -372,7 +372,7 @@ func getVulnerabilityDetails(c ecrClient, detail *ECRImageScanDetail) ([]*grafea
 			}
 		}
 
-		packageUri = *p.Uri
+		packageURI = *p.Uri
 
 		v := &grafeas.Occurrence_Vulnerability{
 			Vulnerability: &vulnerability.Details{
@@ -380,7 +380,7 @@ func getVulnerabilityDetails(c ecrClient, detail *ECRImageScanDetail) ([]*grafea
 				PackageIssue: []*vulnerability.PackageIssue{
 					{
 						AffectedLocation: &vulnerability.VulnerabilityLocation{
-							CpeUri:  packageUri,
+							CpeUri:  packageURI,
 							Package: packageName,
 							Version: &packag.Version{
 								Kind: packag.Version_NORMAL,

--- a/pkg/collector/ecr_events_test.go
+++ b/pkg/collector/ecr_events_test.go
@@ -171,9 +171,9 @@ type mockECRClient struct{}
 func (m *mockECRClient) DescribeImageScanFindings(input *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error) {
 	if _, ok := testFindingsOutput[*input.ImageId.ImageDigest]; ok {
 		return testFindingsOutput[*input.ImageId.ImageDigest], nil
-	} else {
-		return nil, errors.New("error")
-	}
+    }
+
+    return nil, errors.New("error")
 }
 
 func (suite *ECRTestSuite) TestGetNoVulnerabilityDetail() {

--- a/pkg/collector/ecr_events_test.go
+++ b/pkg/collector/ecr_events_test.go
@@ -1,0 +1,245 @@
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+var testPackageDetails = map[string]*ecr.ImageScanFinding{
+	"SEVERITY_UNSPECIFIED": {
+		Name:     aws.String("CVE-2020-8177"),
+		Severity: aws.String("SEVERITY_UNSPECIFIED"),
+		Uri:      aws.String("https://security-tracker.debian.org/tracker/CVE-2020-8177"),
+		Attributes: []*ecr.Attribute{
+			{
+				Key:   aws.String("package_version"),
+				Value: aws.String("7.64.0-4+deb10u1"),
+			},
+			{
+				Key:   aws.String("package_name"),
+				Value: aws.String("curl"),
+			},
+		},
+	},
+	"MINIMAL": {
+		Name:     aws.String("CVE-2017-9117"),
+		Severity: aws.String("INFORMATIONAL"),
+		Uri:      aws.String("https://security-tracker.debian.org/tracker/CVE-2017-9117"),
+		Attributes: []*ecr.Attribute{
+			{
+				Key:   aws.String("package_version"),
+				Value: aws.String("4.1.0+git191117-2~deb10u1"),
+			},
+			{
+				Key:   aws.String("package_name"),
+				Value: aws.String("tiff"),
+			},
+		},
+	},
+	"LOW": {
+		Name:     aws.String("CVE-2020-10029"),
+		Severity: aws.String("LOW"),
+		Uri:      aws.String("https://security-tracker.debian.org/tracker/CVE-2020-10878"),
+		Attributes: []*ecr.Attribute{
+			{
+				Key:   aws.String("package_version"),
+				Value: aws.String("2.28-10"),
+			},
+			{
+				Key:   aws.String("package_name"),
+				Value: aws.String("glibc"),
+			},
+		},
+	},
+	"MEDIUM": {
+		Name:     aws.String("CVE-2019-3844"),
+		Severity: aws.String("MEDIUM"),
+		Uri:      aws.String("https://security-tracker.debian.org/tracker/CVE-2019-3844"),
+		Attributes: []*ecr.Attribute{
+			{
+				Key:   aws.String("package_version"),
+				Value: aws.String("241-7~deb10u4"),
+			},
+			{
+				Key:   aws.String("package_name"),
+				Value: aws.String("systemd"),
+			},
+		},
+	},
+	"HIGH": {
+		Name:     aws.String("CVE-2020-10878"),
+		Severity: aws.String("HIGH"),
+		Uri:      aws.String("https://security-tracker.debian.org/tracker/CVE-2020-10878"),
+		Attributes: []*ecr.Attribute{
+			{
+				Key:   aws.String("package_version"),
+				Value: aws.String("5.28.1-6"),
+			},
+			{
+				Key:   aws.String("package_name"),
+				Value: aws.String("perl"),
+			},
+		},
+	},
+	"CRITICAL": {
+		Name:     aws.String("CVE-2019-12400"),
+		Severity: aws.String("CRITICAL"),
+		Uri:      aws.String("https://security-tracker.debian.org/tracker/CVE-2019-12400"),
+		Attributes: []*ecr.Attribute{
+			{
+				Key:   aws.String("package_version"),
+				Value: aws.String("1.5.8-2"),
+			},
+			{
+				Key:   aws.String("package_name"),
+				Value: aws.String("libxml-security-java"),
+			},
+		},
+	},
+}
+
+var testFindingsOutput = map[string]*ecr.DescribeImageScanFindingsOutput{
+	"zeroVulnerabilities": {
+		ImageScanStatus: &ecr.ImageScanStatus{
+			Status: aws.String(ecr.ScanStatusComplete),
+		},
+		ImageScanFindings: &ecr.ImageScanFindings{
+			FindingSeverityCounts: map[string]*int64{
+				ecr.FindingSeverityUndefined:     aws.Int64(0),
+				ecr.FindingSeverityInformational: aws.Int64(0),
+				ecr.FindingSeverityLow:           aws.Int64(0),
+				ecr.FindingSeverityMedium:        aws.Int64(0),
+				ecr.FindingSeverityHigh:          aws.Int64(0),
+				ecr.FindingSeverityCritical:      aws.Int64(0),
+			},
+		},
+	},
+	"singleVulnerability": {
+		ImageScanStatus: &ecr.ImageScanStatus{
+			Status: aws.String(ecr.ScanStatusComplete),
+		},
+		ImageScanFindings: &ecr.ImageScanFindings{
+			FindingSeverityCounts: map[string]*int64{
+				ecr.FindingSeverityUndefined:     aws.Int64(0),
+				ecr.FindingSeverityInformational: aws.Int64(0),
+				ecr.FindingSeverityLow:           aws.Int64(0),
+				ecr.FindingSeverityMedium:        aws.Int64(0),
+				ecr.FindingSeverityHigh:          aws.Int64(0),
+				ecr.FindingSeverityCritical:      aws.Int64(1),
+			},
+			Findings: []*ecr.ImageScanFinding{
+				testPackageDetails["CRITICAL"],
+			},
+		},
+	},
+	"manyVulnerabilities": {
+		ImageScanStatus: &ecr.ImageScanStatus{
+			Status: aws.String(ecr.ScanStatusComplete),
+		},
+		ImageScanFindings: &ecr.ImageScanFindings{
+			FindingSeverityCounts: map[string]*int64{
+				ecr.FindingSeverityUndefined:     aws.Int64(1),
+				ecr.FindingSeverityInformational: aws.Int64(1),
+				ecr.FindingSeverityLow:           aws.Int64(1),
+				ecr.FindingSeverityMedium:        aws.Int64(1),
+				ecr.FindingSeverityHigh:          aws.Int64(1),
+				ecr.FindingSeverityCritical:      aws.Int64(1),
+			},
+			Findings: []*ecr.ImageScanFinding{
+				testPackageDetails["SEVERITY_UNSPECIFIED"],
+				testPackageDetails["MINIMAL"],
+				testPackageDetails["LOW"],
+				testPackageDetails["MEDIUM"],
+				testPackageDetails["HIGH"],
+				testPackageDetails["CRITICAL"],
+			},
+		},
+	},
+}
+
+type ECRTestSuite struct {
+	suite.Suite
+}
+
+type mockECRClient struct{}
+
+func (m *mockECRClient) DescribeImageScanFindings(input *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error) {
+	if _, ok := testFindingsOutput[*input.ImageId.ImageDigest]; ok {
+		return testFindingsOutput[*input.ImageId.ImageDigest], nil
+	} else {
+		return nil, errors.New("error")
+	}
+}
+
+func (suite *ECRTestSuite) TestGetNoVulnerabilityDetail() {
+	client := &mockECRClient{}
+
+	testECRDetail := &ECRImageScanDetail{
+		ScanStatus:     ecr.ScanStatusComplete,
+		RepositoryName: "testRepo",
+		ImageDigest:    "zeroVulnerabilities",
+	}
+
+	vulnerabilityOccurences, _ := getVulnerabilityDetails(client, testECRDetail)
+
+	assert.Len(suite.T(), vulnerabilityOccurences, 0)
+}
+
+func (suite *ECRTestSuite) TestGetOneVulnerabilityDetail() {
+	client := &mockECRClient{}
+
+	testECRDetail := &ECRImageScanDetail{
+		ScanStatus:     ecr.ScanStatusComplete,
+		RepositoryName: "testRepo",
+		ImageDigest:    "singleVulnerability",
+	}
+
+	result, _ := getVulnerabilityDetails(client, testECRDetail)
+
+	assert.Len(suite.T(), result, 1)
+	assert.Equal(suite.T(), result[0].Vulnerability.Severity.String(), *testPackageDetails["CRITICAL"].Severity)
+	assert.Equal(suite.T(), result[0].Vulnerability.PackageIssue[0].AffectedLocation.CpeUri, *testPackageDetails["CRITICAL"].Uri)
+	assert.Equal(suite.T(), result[0].Vulnerability.PackageIssue[0].AffectedLocation.Version.Name, *testPackageDetails["CRITICAL"].Attributes[0].Value)
+	assert.Equal(suite.T(), result[0].Vulnerability.PackageIssue[0].AffectedLocation.Package, *testPackageDetails["CRITICAL"].Attributes[1].Value)
+}
+
+func (suite *ECRTestSuite) TestGetMultipleVulnerabilityDetail() {
+	client := &mockECRClient{}
+
+	testECRDetail := &ECRImageScanDetail{
+		ScanStatus:     ecr.ScanStatusComplete,
+		RepositoryName: "testRepo",
+		ImageDigest:    "manyVulnerabilities",
+	}
+
+	result, _ := getVulnerabilityDetails(client, testECRDetail)
+
+	assert.Len(suite.T(), result, 6)
+	for i := range result {
+		s := result[i].Vulnerability.Severity.String()
+		assert.Equal(suite.T(), result[i].Vulnerability.PackageIssue[0].AffectedLocation.CpeUri, *testPackageDetails[s].Uri)
+		assert.Equal(suite.T(), result[i].Vulnerability.PackageIssue[0].AffectedLocation.Version.Name, *testPackageDetails[s].Attributes[0].Value)
+	}
+}
+
+func (suite *ECRTestSuite) TestBadInput() {
+	client := &mockECRClient{}
+
+	testECRDetail := &ECRImageScanDetail{
+		ScanStatus:     ecr.ScanStatusComplete,
+		RepositoryName: "testRepo",
+		ImageDigest:    "nonExistentImage",
+	}
+
+  _, err := getVulnerabilityDetails(client, testECRDetail)
+
+  assert.Error(suite.T(), err)
+}
+func TestECRTestSuite(t *testing.T) {
+	suite.Run(t, new(ECRTestSuite))
+}

--- a/pkg/collector/ecr_events_test.go
+++ b/pkg/collector/ecr_events_test.go
@@ -171,9 +171,9 @@ type mockECRClient struct{}
 func (m *mockECRClient) DescribeImageScanFindings(input *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error) {
 	if _, ok := testFindingsOutput[*input.ImageId.ImageDigest]; ok {
 		return testFindingsOutput[*input.ImageId.ImageDigest], nil
-    }
+	}
 
-    return nil, errors.New("error")
+	return nil, errors.New("error")
 }
 
 func (suite *ECRTestSuite) TestGetNoVulnerabilityDetail() {
@@ -236,9 +236,9 @@ func (suite *ECRTestSuite) TestBadInput() {
 		ImageDigest:    "nonExistentImage",
 	}
 
-  _, err := getVulnerabilityDetails(client, testECRDetail)
+	_, err := getVulnerabilityDetails(client, testECRDetail)
 
-  assert.Error(suite.T(), err)
+	assert.Error(suite.T(), err)
 }
 func TestECRTestSuite(t *testing.T) {
 	suite.Run(t, new(ECRTestSuite))


### PR DESCRIPTION
This PR will add ECR Scan details to Vulnerability Occurences when events are detected by the ECR collector. A new call to the AWS ECR service has been added to pull down related package details. The following metadata is now defined for ECR Vulnerability Occurrences:
- CVE Uri
- Package Name
- Package Version

In order to support Unit testing a `ECRClient` interface was added to support stubbing the `DescribeImageScanFindings` function from the AWS SDK.