### PR TITLE
Fixed typo in localstack deployment release label

### DIFF
--- a/helm-chart/rode/charts/localstack/templates/deployment.yaml
+++ b/helm-chart/rode/charts/localstack/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "name" . }}
-      release: {{ .Release.name }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR will fix my oversight in adding the `release` label to the deployment template in the Localstack helmchart. 

`{{ .Release.name }}` -> `{{ .Release.Name }}`